### PR TITLE
geom_point to geom_pointdensity in fast.colour.plot

### DIFF
--- a/R/fast.colour.plot.R
+++ b/R/fast.colour.plot.R
@@ -464,7 +464,7 @@ fast.colour.plot <- function(dat,
         p <- ggplot(data = dat,
                     aes(x = .data[[x.axis]],
                         y = .data[[y.axis]])) +
-            ggpointdensity::geom_point(size = dot.size)
+            ggpointdensity::geom_pointdensity(size = dot.size)
         
         if (colours == "viridis" ||
             colours == "magma" || colours == "inferno") {


### PR DESCRIPTION
**To the attention of** @tomashhurst 

**Changed the ggpointdensity::geom_point to ggpointdensity::geom_pointdensity as this was giving the error 'Error: 'geom_point' is not an exported object from 'namespace:ggpointdensity''**

**Issue:** Ran into the error `'Error: 'geom_point' is not an exported object from 'namespace:ggpointdensity'` when running Spectre::fast.colour.plot(). 

**Packages:** Spectre development (1.0.0-0), ggplot2 (3.4.2)

**Testing:** Minimal testing on my own data.

**Documentation:** Not required

**Vignette:** No changes or additions required

**Verbose Description:** Was using the development version of Spectre to access `truncate_max_range = FALSE` in `Spectre::read.files` and came across the `Spectre::fast.colour.plot` function. When attempting to use it the above mentioned error was given. I substituted `ggpointdensity::geom_point` for `ggpointdensity::geom_pointdensity` which used in `make.colour.plot`. This solved the issue. I have little experience with pull request, so feel free to ignore. Please suggest what unit tests would be appropriate in this case. All the best.